### PR TITLE
Migrate to discord.py 2.7.1

### DIFF
--- a/classes/bot.py
+++ b/classes/bot.py
@@ -9,11 +9,11 @@ import aiohttp
 import aioredis
 import asyncpg
 import orjson
+import discord
 
 from discord.ext import commands
 from discord.ext.commands.core import _CaseInsensitiveDict
 from discord.gateway import DiscordClientWebSocketResponse, DiscordWebSocket
-from discord.utils import parse_time
 from groq import AsyncGroq
 
 from classes.http import HTTPClient
@@ -28,26 +28,19 @@ log = logging.getLogger(__name__)
 
 class ModMail(commands.AutoShardedBot):
     def __init__(self, command_prefix=None, **kwargs):
-        self.command_prefix = command_prefix
-        self.extra_events = {}
-        self._BotBase__cogs = {}
-        self._BotBase__extensions = {}
-        self._checks = []
-        self._check_once = []
-        self._before_invoke = None
-        self._after_invoke = None
-        self._help_command = None
-        self.description = ""
-        self.owner_id = None
-        self.owner_ids = set()
-        self._skip_check = lambda x, y: x == y
-        self.case_insensitive = True
-        self.all_commands = _CaseInsensitiveDict() if self.case_insensitive else {}
-        self.strip_after_prefix = False
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.members = True
+
+        super().__init__(
+            command_prefix=command_prefix,
+            intents=intents,
+            case_insensitive=True,
+            **kwargs
+        )
 
         self.ws = None
-        self.loop = asyncio.get_event_loop()
-        self.http = HTTPClient(None, loop=self.loop)
+        self.http = HTTPClient(None)
 
         self._handlers = {"ready": self._handle_ready}
         self._hooks = {}
@@ -123,7 +116,10 @@ class ModMail(commands.AutoShardedBot):
         return int(await self._connection.get("gateway_shards"))
 
     async def started(self):
-        return parse_time(str(await self._connection.get("gateway_started")).split(".")[0])
+        started_at = await self._connection.get("gateway_started")
+        if started_at:
+            return discord.utils.parse_time(str(started_at).split(".")[0])
+        return None
 
     async def statuses(self):
         return [Status(x) for x in await self._connection.get("gateway_statuses")]
@@ -222,16 +218,26 @@ class ModMail(commands.AutoShardedBot):
         )
         return completion.choices[0].message.content
 
+    async def setup_hook(self):
+        self.prom = Prometheus(self)
+        await self.prom.start()
+
+        if self.config.GROQ_KEY is not None:
+            self.ai = AsyncGroq(api_key=self.config.GROQ_KEY)
+
     async def start(self, worker=True):
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(self.on_http_request_start)
         trace_config.on_request_end.append(self.on_http_request_end)
+
+        self.http.connector = aiohttp.TCPConnector()
         self.http._HTTPClient__session = aiohttp.ClientSession(
             connector=self.http.connector,
             ws_response_class=DiscordClientWebSocketResponse,
             trace_configs=[trace_config],
         )
-        self.http._token(self.config.BOT_TOKEN, bot=True)
+        self.http.token = self.config.BOT_TOKEN
+        self.session = self.http._HTTPClient__session
 
         self.pool = await asyncpg.create_pool(
             database=self.config.POSTGRES_DATABASE,
@@ -267,34 +273,34 @@ class ModMail(commands.AutoShardedBot):
         if self.config.GROQ_KEY is not None:
             self.ai = AsyncGroq(api_key=self.config.GROQ_KEY)
 
+        shard_count_val = await self._redis.get("gateway_shards")
         self._connection = State(
             id=self.id,
             dispatch=self.dispatch,
             handlers=self._handlers,
             hooks=self._hooks,
             http=self.http,
-            loop=self.loop,
+            loop=asyncio.get_event_loop(),
             redis=self._redis,
-            shard_count=int(await self._redis.get("gateway_shards")),
+            shard_count=int(shard_count_val) if shard_count_val else 1,
         )
         self._connection._get_client = lambda: self
 
-        self.ws = DiscordWebSocket(socket=None, loop=self.loop)
-        self.ws.token = self.http.token
+        self.ws = DiscordWebSocket(socket=None, loop=asyncio.get_event_loop())
+        self.ws.token = self.config.BOT_TOKEN
         self.ws._connection = self._connection
         self.ws._discord_parsers = self._connection.parsers
         self.ws._dispatch = self.dispatch
-        self.ws.call_hooks = self._connection.call_hooks
 
         if not worker:
             return
 
         for extension in self._cogs:
             try:
-                self.load_extension("cogs." + extension)
+                await self.load_extension("cogs." + extension)
             except Exception:
                 log.error(f"Failed to load extension {extension}.", file=sys.stderr)
-                log.error(traceback.print_exc())
+                log.error(traceback.format_exc())
 
         async with self._amqp_queue.iterator() as queue_iter:
             async for message in queue_iter:

--- a/classes/channel.py
+++ b/classes/channel.py
@@ -1,7 +1,7 @@
 import logging
 
 from discord import channel, utils
-from discord.channel import CategoryChannel, GroupChannel, StageChannel, StoreChannel, VoiceChannel
+from discord.channel import CategoryChannel, GroupChannel, StageChannel, VoiceChannel
 from discord.enums import ChannelType, try_enum
 from discord.permissions import Permissions
 
@@ -121,8 +121,6 @@ def _channel_factory(channel_type):
         return GroupChannel, value
     elif value is ChannelType.news:
         return TextChannel, value
-    elif value is ChannelType.store:
-        return StoreChannel, value
     elif value is ChannelType.stage_voice:
         return StageChannel, value
     else:

--- a/classes/embed.py
+++ b/classes/embed.py
@@ -11,7 +11,7 @@ class Embed(embeds.Embed):
             kwargs["colour"] = 0x1E90FF
 
         if kwargs.get("timestamp", False) is True:
-            kwargs["timestamp"] = datetime.datetime.utcnow()
+            kwargs["timestamp"] = discord.utils.utcnow()
 
         if len(args) == 2:
             kwargs["title"] = args[0]
@@ -21,16 +21,16 @@ class Embed(embeds.Embed):
 
         super().__init__(**kwargs)
 
-    def set_author(self, name=discord.Embed.Empty, icon_url=discord.Embed.Empty, **kwargs):
+    def set_author(self, name=None, icon_url=None, **kwargs):
         super().set_author(name=name, icon_url=icon_url, **kwargs)
 
-    def set_footer(self, text=discord.Embed.Empty, icon_url=discord.Embed.Empty):
+    def set_footer(self, text=None, icon_url=None):
         super().set_footer(text=text, icon_url=icon_url)
 
-    def set_thumbnail(self, url=discord.Embed.Empty):
+    def set_thumbnail(self, url=None):
         super().set_thumbnail(url=url)
 
-    def add_field(self, name=discord.Embed.Empty, value=discord.Embed.Empty, inline=True):
+    def add_field(self, name=None, value=None, inline=True):
         super().add_field(name=name, value=value, inline=inline)
 
 

--- a/classes/guild.py
+++ b/classes/guild.py
@@ -8,7 +8,6 @@ from discord.enums import (
     ContentFilter,
     NotificationLevel,
     VerificationLevel,
-    VoiceRegion,
     try_enum,
 )
 from discord.member import VoiceState
@@ -55,7 +54,6 @@ class Guild(guild.Guild):
             self._member_count = 0
 
         self.name = guild.get("name")
-        self.region = try_enum(VoiceRegion, guild.get("region"))
         self.verification_level = try_enum(VerificationLevel, guild.get("verification_level"))
         self.default_notifications = try_enum(
             NotificationLevel, guild.get("default_message_notifications")
@@ -64,13 +62,13 @@ class Guild(guild.Guild):
             ContentFilter, guild.get("explicit_content_filter", 0)
         )
         self.afk_timeout = guild.get("afk_timeout")
-        self.icon = guild.get("icon")
-        self.banner = guild.get("banner")
+        self._icon = guild.get("icon")
+        self._banner = guild.get("banner")
         self.unavailable = guild.get("unavailable", False)
         self.id = int(guild["id"])
         self.mfa_level = guild.get("mfa_level")
         self.features = guild.get("features", [])
-        self.splash = guild.get("splash")
+        self._splash = guild.get("splash")
         self._system_channel_id = utils._get_as_snowflake(guild, "system_channel_id")
         self.description = guild.get("description")
         self.max_presences = guild.get("max_presences")
@@ -80,7 +78,7 @@ class Guild(guild.Guild):
         self.premium_subscription_count = guild.get("premium_subscription_count") or 0
         self._system_channel_flags = guild.get("system_channel_flags", 0)
         self.preferred_locale = guild.get("preferred_locale")
-        self.discovery_splash = guild.get("discovery_splash")
+        self._discovery_splash = guild.get("discovery_splash")
         self._rules_channel_id = utils._get_as_snowflake(guild, "rules_channel_id")
         self._public_updates_channel_id = utils._get_as_snowflake(
             guild, "public_updates_channel_id"

--- a/classes/member.py
+++ b/classes/member.py
@@ -17,6 +17,7 @@ class Member(member.Member):
         self.premium_since = utils.parse_time(data.get("premium_since"))
         self._update_roles(data)
         self.nick = data.get("nick", None)
+        self._avatar = data.get("user", {}).get("avatar")
 
     async def guild_permissions(self):
         if self.guild.owner_id == self.id:

--- a/classes/state.py
+++ b/classes/state.py
@@ -164,7 +164,7 @@ class State:
 
     async def _users(self):
         user_ids = set([x.split(":")[2] for x in await self._members("member")])
-        return [User(state=self, data=x["user"]) for x in await self.get(user_ids)]
+        return [User(state=self, data=x["user"]) for x in await self.get(list(user_ids))]
 
     async def _emojis(self):
         results = await self._members_get_all("emoji")
@@ -375,7 +375,7 @@ class State:
 
         self.dispatch("connect")
         self._ready_state = asyncio.Queue()
-        self._ready_task = asyncio.ensure_future(self._delay_ready(), loop=self.loop)
+        self._ready_task = asyncio.ensure_future(self._delay_ready())
 
     async def parse_resumed(self, data, old):
         self.dispatch("resumed")
@@ -519,7 +519,7 @@ class State:
             if user_update:
                 self.dispatch("user_update", user_update[1], user_update[0])
 
-        self.dispatch("member_update", old_member, member)
+        self.dispatch("presence_update", old_member, member)
 
     async def parse_user_update(self, data, old):
         return
@@ -754,7 +754,7 @@ class State:
                     "typing",
                     channel,
                     member,
-                    datetime.datetime.utcfromtimestamp(data.get("timestamp")),
+                    datetime.datetime.fromtimestamp(data.get("timestamp"), tz=datetime.timezone.utc),
                 )
 
     async def parse_relationship_add(self, data, old):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -43,7 +43,7 @@ class Admin(commands.Cog):
             page = Embed(title="Shared Servers")
 
             for guild in chunk:
-                if page.description == discord.Embed.Empty:
+                if page.description is None:
                     page.description = guild
                 else:
                     page.description += f"\n{guild}"
@@ -130,5 +130,5 @@ class Admin(commands.Cog):
         await self.bot.session.post(f"{self.bot.http_uri}/restart")
 
 
-def setup(bot):
-    bot.add_cog(Admin(bot))
+async def setup(bot):
+    await bot.add_cog(Admin(bot))

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -501,5 +501,5 @@ class Configuration(commands.Cog):
         await ctx.send(embed)
 
 
-def setup(bot):
-    bot.add_cog(Configuration(bot))
+async def setup(bot):
+    await bot.add_cog(Configuration(bot))

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -105,7 +105,7 @@ class Core(commands.Cog):
 
     async def generate_history(self, channel):
         history = ""
-        messages = await channel.history(limit=10000).flatten()
+        messages = [message async for message in channel.history(limit=10000)]
 
         for message in messages:
             if message.author.bot and (
@@ -167,10 +167,10 @@ class Core(commands.Cog):
             reason if reason else "No reason was provided.",
             timestamp=True,
         )
-        embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
+        embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
 
         if anon is False:
-            embed.set_author(str(ctx.author.name), ctx.author.avatar_url)
+            embed.set_author(str(ctx.author.name), ctx.author.display_avatar.url)
 
         try:
             member = await ctx.guild.fetch_member(tools.get_modmail_user(ctx.channel).id)
@@ -186,7 +186,7 @@ class Core(commands.Cog):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
+                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
                 try:
                     await dm_channel.send(embed2)
                 except discord.Forbidden:
@@ -211,7 +211,7 @@ class Core(commands.Cog):
                 pass
 
         if member:
-            embed.set_footer(f"{member.name} | {member.id}", member.avatar_url)
+            embed.set_footer(f"{member.name} | {member.id}", member.display_avatar.url)
         else:
             embed.set_footer(
                 "Unknown | 000000000000000000",
@@ -220,7 +220,7 @@ class Core(commands.Cog):
 
         embed.set_author(
             str(ctx.author.name) if anon is False else f"{ctx.author.name} (Anonymous)",
-            ctx.author.avatar_url,
+            ctx.author.display_avatar.url,
         )
 
         if data[7] > 0:
@@ -420,12 +420,12 @@ class Core(commands.Cog):
 
         if len(all_pages) == 1:
             embed = all_pages[0]
-            embed.set_footer(discord.Embed.Empty)
+            embed.set_footer(None)
             await ctx.send(embed)
             return
 
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-def setup(bot):
-    bot.add_cog(Core(bot))
+async def setup(bot):
+    await bot.add_cog(Core(bot))

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -65,7 +65,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     data[12] if data[12] else "No reason was provided.",
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
                 await message.channel.send(embed)
                 return
 
@@ -123,7 +123,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 )
                 embed.set_footer(
                     f"{message.author.name} | {message.author.id}",
-                    message.author.avatar_url,
+                    message.author.display_avatar.url,
                 )
 
                 try:
@@ -162,7 +162,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 ),
             )
             embed.set_footer(
-                f"{message.author.name} | {message.author.id}", message.author.avatar_url
+                f"{message.author.name} | {message.author.id}", message.author.display_avatar.url
             )
 
             roles = []
@@ -191,12 +191,12 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
 
                 await message.channel.send(embed)
 
         embed = Embed("Message Sent", message.content, colour=0x00FF00, timestamp=True)
-        embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+        embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
 
         files = []
         for file in message.attachments:
@@ -209,7 +209,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         embed.title = "Message Received"
         embed.set_footer(
             f"{message.author.name} | {message.author.id}",
-            message.author.avatar_url,
+            message.author.display_avatar.url,
         )
 
         for count, attachment in enumerate(
@@ -325,7 +325,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
     @commands.Cog.listener()
     async def on_message(self, message):
         if (
-            message.is_system()
+            message.is_system
             or message.author.bot
             or not isinstance(message.channel, discord.DMChannel)
         ):
@@ -453,5 +453,5 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         await ctx.send(Embed("Confirmation messages are enabled."))
 
 
-def setup(bot):
-    bot.add_cog(DirectMessageEvents(bot))
+async def setup(bot):
+    await bot.add_cog(DirectMessageEvents(bot))

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -93,5 +93,5 @@ class ErrorHandler(commands.Cog):
                 pass
 
 
-def setup(bot):
-    bot.add_cog(ErrorHandler(bot))
+async def setup(bot):
+    await bot.add_cog(ErrorHandler(bot))

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -138,5 +138,5 @@ class Events(commands.Cog):
         await self.bot.invoke(ctx)
 
 
-def setup(bot):
-    bot.add_cog(Events(bot))
+async def setup(bot):
+    await bot.add_cog(Events(bot))

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,6 +1,7 @@
 import logging
 import platform
 import time
+import discord
 
 from datetime import datetime
 
@@ -63,7 +64,7 @@ class General(commands.Cog):
             "can also invite me to your server with the link below, or join our support server if "
             f"you need further help.\n\nTo setup the bot, run `{ctx.prefix}setup`.",
         )
-        page.set_thumbnail(bot_user.avatar_url)
+        page.set_thumbnail(bot_user.display_avatar.url)
         page.set_footer("Use the reactions to flip pages.")
         page.add_field("Invite", f"{self.bot.config.BASE_URI}/invite", False)
         page.add_field("Support Server", "https://discord.gg/wjWJwJB", False)
@@ -85,8 +86,8 @@ class General(commands.Cog):
                 "information on a command.",
             )
 
-            page.set_author("ModMail Help Menu", bot_user.avatar_url)
-            page.set_thumbnail(bot_user.avatar_url)
+            page.set_author("ModMail Help Menu", bot_user.display_avatar.url)
+            page.set_thumbnail(bot_user.display_avatar.url)
             page.set_footer("Use the reactions to flip pages.")
 
             for cmd in cog_commands:
@@ -122,7 +123,7 @@ class General(commands.Cog):
         aliases=["statistics", "info"],
     )
     async def stats(self, ctx):
-        total_seconds = int((datetime.utcnow() - await self.bot.started()).total_seconds())
+        total_seconds = int((discord.utils.utcnow() - await self.bot.started()).total_seconds())
         hours, remainder = divmod(total_seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
         days, hours = divmod(hours, 24)
@@ -149,7 +150,7 @@ class General(commands.Cog):
         embed.add_field("CPU Usage", f"{psutil.cpu_percent(interval=None)}%")
         embed.add_field("RAM Usage", f"{psutil.virtual_memory().percent}%")
         embed.add_field("Python Version", platform.python_version())
-        embed.set_thumbnail(bot_user.avatar_url)
+        embed.set_thumbnail(bot_user.display_avatar.url)
 
         await ctx.send(embed)
 
@@ -180,5 +181,5 @@ class General(commands.Cog):
         await ctx.send(Embed("GitHub Repository", "https://github.com/chamburr/modmail"))
 
 
-def setup(bot):
-    bot.add_cog(General(bot))
+async def setup(bot):
+    await bot.add_cog(General(bot))

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -57,7 +57,7 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Name", str(member) if member.bot else str(member.name), False)
         embed.add_field("ID", member.id)
         embed.add_field("Nickname", member.nick if member.nick else "*Not set*")
-        embed.add_field("Avatar", f"[Link]({member.avatar_url_as(static_format='png')})")
+        embed.add_field("Avatar", f"[Link]({member.display_avatar.replace(static_format='png').url})")
         embed.add_field(
             "Joined Server",
             f"<t:{round(member.joined_at.timestamp())}:R>" if member.joined_at else "Unknown",
@@ -67,7 +67,7 @@ class Miscellaneous(commands.Cog):
             "Roles",
             f"{len(roles)} roles" if len(", ".join(roles)) > 1000 else ", ".join(roles),
         )
-        embed.set_thumbnail(member.avatar_url)
+        embed.set_thumbnail(member.display_avatar.url)
 
         await ctx.send(embed)
 
@@ -86,7 +86,7 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Owner", f"<@{guild.owner_id}>" if guild.owner_id else "Unknown")
         embed.add_field(
             "Icon",
-            f"[Link]({guild.icon_url_as(static_format='png')})" if guild.icon else "*Not set*",
+            f"[Link]({guild.icon.replace(static_format='png').url})" if guild.icon else "*Not set*",
         )
         embed.add_field("Server Created", f"<t:{round(guild.created_at.timestamp())}:R>")
         embed.add_field("Members", guild.member_count)
@@ -94,10 +94,10 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Roles", str(len(await guild.roles())))
 
         if guild.icon:
-            embed.set_thumbnail(guild.icon_url)
+            embed.set_thumbnail((guild.icon.url if guild.icon else None))
 
         await ctx.send(embed)
 
 
-def setup(bot):
-    bot.add_cog(Miscellaneous(bot))
+async def setup(bot):
+    await bot.add_cog(Miscellaneous(bot))

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -72,10 +72,10 @@ class ModMailEvents(commands.Cog):
             message.content = tools.tag_format(message.content, member)
 
         embed = Embed("Message Received", message.content, colour=0xFF4500, timestamp=True)
-        embed.set_footer(f"{message.guild.name} | {message.guild.id}", message.guild.icon_url)
+        embed.set_footer(f"{message.guild.name} | {message.guild.id}", (message.guild.icon.url if message.guild.icon else None))
 
         if anon is False:
-            embed.set_author(str(message.author.name), message.author.avatar_url)
+            embed.set_author(str(message.author.name), message.author.display_avatar.url)
 
         files = []
         for file in message.attachments:
@@ -98,9 +98,9 @@ class ModMailEvents(commands.Cog):
         embed.title = "Message Sent"
         embed.set_author(
             str(message.author.name) if anon is False else f"{message.author.name} (Anonymous)",
-            message.author.avatar_url,
+            message.author.display_avatar.url,
         )
-        embed.set_footer(f"{member.name} | {member.id}", member.avatar_url)
+        embed.set_footer(f"{member.name} | {member.id}", member.display_avatar.url)
 
         for count, attachment in enumerate(
             [attachment.url for attachment in dm_message.attachments], start=1
@@ -118,5 +118,5 @@ class ModMailEvents(commands.Cog):
             pass
 
 
-def setup(bot):
-    bot.add_cog(ModMailEvents(bot))
+async def setup(bot):
+    await bot.add_cog(ModMailEvents(bot))

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -170,5 +170,5 @@ class Owner(commands.Cog):
         await ctx.send(Embed("Successfully unbanned that server from the bot."))
 
 
-def setup(bot):
-    bot.add_cog(Owner(bot))
+async def setup(bot):
+    await bot.add_cog(Owner(bot))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -150,5 +150,5 @@ class Premium(commands.Cog):
         await ctx.send(Embed("The server no longer has premium."))
 
 
-def setup(bot):
-    bot.add_cog(Premium(bot))
+async def setup(bot):
+    await bot.add_cog(Premium(bot))

--- a/cogs/snippet.py
+++ b/cogs/snippet.py
@@ -173,12 +173,12 @@ class Snippet(commands.Cog):
 
         if len(all_pages) == 1:
             embed = all_pages[0]
-            embed.set_footer(discord.Embed.Empty)
+            embed.set_footer(None)
             await ctx.send(embed)
             return
 
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-def setup(bot):
-    bot.add_cog(Snippet(bot))
+async def setup(bot):
+    await bot.add_cog(Snippet(bot))

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class Scheduler:
             async with self.bot.pool.acquire() as conn:
                 premium = await conn.fetch(
                     "SELECT identifier, guild FROM premium WHERE expiry IS NOT NULL AND expiry<$1",
-                    int(datetime.utcnow().timestamp() * 1000),
+                    int(discord.utils.utcnow().timestamp() * 1000),
                 )
 
                 for row in premium:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aio-pika==9.4.0
-aiohttp==3.7.4.post0
+aiohttp>=3.10.0
 aioprometheus==23.3.0
 aioredis==1.3.1
 asyncpg==0.29.0
@@ -9,5 +9,4 @@ orjson==3.9.13
 psutil==5.9.8
 python-dotenv==1.0.1
 subprocess32==3.5.4
-
-git+https://github.com/chamburr/discord.py.git
+discord.py==2.7.1

--- a/worker.py
+++ b/worker.py
@@ -46,4 +46,11 @@ async def on_message(_):
     pass
 
 
-loop.run_until_complete(bot.start())
+async def main():
+    async with bot:
+        await bot.start()
+
+try:
+    loop.run_until_complete(main())
+except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
This PR migrates the ModMail bot from a custom discord.py 1.x fork to the latest official discord.py 2.7.1.

Key changes:
- Mandatory intents configuration.
- Asynchronous cog loading and bot startup.
- Migration of Asset attributes (avatar, icon) and helper methods.
- Switch to UTC-aware datetimes using discord.utils.utcnow().
- Fixes for internal class instantiations (State, DiscordWebSocket).
- Preservation of the custom Redis-based state management.

---
*PR created automatically by Jules for task [18395647179954206482](https://jules.google.com/task/18395647179954206482) started by @dlsnyder8*